### PR TITLE
Update config-sans-multani.yaml

### DIFF
--- a/sources/config-sans-multani.yaml
+++ b/sources/config-sans-multani.yaml
@@ -9,5 +9,4 @@ includeSubsets:
     - start: 0x0964
       end: 0x0965
 sources:
-sources:
 - NotoSansMultani.designspace


### PR DESCRIPTION
gftools builder doesn't allow double keys

```
  File "C:\Program Files\Python312\Scripts\gftools.exe\__main__.py", line 7, in <module>
  File "C:\Program Files\Python312\Lib\site-packages\gftools\scripts\__init__.py", line 91, in main
    mod.main(args[2:])
  File "C:\Program Files\Python312\Lib\site-packages\gftools\builder\__init__.py", line 686, in main
    builder = builder_class(**builder_args)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Program Files\Python312\Lib\site-packages\gftools\builder\__init__.py", line 157, in __init__
    self.config = self.load_config(configfile)
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Program Files\Python312\Lib\site-packages\gftools\builder\__init__.py", line 170, in load_config
    return load(unprocessed_yaml, self.schema).data
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Program Files\Python312\Lib\site-packages\strictyaml\parser.py", line 323, in load
    return generic_load(yaml_string, schema=schema, label=label)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Program Files\Python312\Lib\site-packages\strictyaml\parser.py", line 292, in generic_load
    raise parse_error
  File "C:\Program Files\Python312\Lib\site-packages\strictyaml\parser.py", line 285, in generic_load
    document = ruamelyaml.load(yaml_string, Loader=DynamicStrictYAMLLoader)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Program Files\Python312\Lib\site-packages\strictyaml\ruamel\main.py", line 986, in load
    return loader._constructor.get_single_data()
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Program Files\Python312\Lib\site-packages\strictyaml\ruamel\constructor.py", line 116, in get_single_data
    return self.construct_document(node)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Program Files\Python312\Lib\site-packages\strictyaml\ruamel\constructor.py", line 126, in construct_document
    for _dummy in generator:
  File "C:\Program Files\Python312\Lib\site-packages\strictyaml\ruamel\constructor.py", line 1645, in construct_yaml_map
    self.construct_mapping(node, data, deep=True)
  File "C:\Program Files\Python312\Lib\site-packages\strictyaml\parser.py", line 101, in construct_mapping
    raise exceptions.DuplicateKeysDisallowed(
strictyaml.exceptions.DuplicateKeysDisallowed: While parsing
  in "<unicode string>", line 3, column 1:
    sources:
    ^ (line: 3)
Duplicate key 'sources' found
  in "<unicode string>", line 3, column 8:
    sources:
           ^ (line: 3)
```